### PR TITLE
Added missing comma in setup.py

### DIFF
--- a/pyfasst/SeparateLeadStereo/setup.py
+++ b/pyfasst/SeparateLeadStereo/setup.py
@@ -3,6 +3,6 @@ from distutils.core import setup
 setup(
     name="SeparateLeadStereo",
     version='0.3',
-    packages=['SIMM', 'tracking']
+    packages=['SIMM', 'tracking'],
     license='',
     )


### PR DESCRIPTION
Fixes this error:

c:\pyFASST-0.9.2\pyfasst\SeparateLeadStereo>python setup.py build_ext --inplace
  File "setup.py", line 7
    license='',
          ^
SyntaxError: invalid syntax
