### PR TITLE
Add continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+- 2.7
+- 3.6
+install:
+- pip install cython
+- pip install -e .
+script:
+- nosetests tests -v --with-coverage --cover-package=pyfasst


### PR DESCRIPTION
It would be nice to know the state of this repo in terms of passing tests, code coverage and so on so maybe it would be nice to run them automatically on code changes with a free CI such as [Travis](https://travis-ci.org/). It's fairly standard practice on GitHub these days.

Continuous integration is particularly important as dependencies such as NumPy changes over time which could accidentally break pyFASST.

I've added an initial .travis.yml in this pull request. Could you consider registering this repo at https://travis-ci.org/ and merging this to master so testing is automated?